### PR TITLE
Refactor screen brightness fading to threaded, non-blocking

### DIFF
--- a/boards/shields/dongle_screen/src/brightness.c
+++ b/boards/shields/dongle_screen/src/brightness.c
@@ -7,7 +7,6 @@
 #include <zmk/events/keycode_state_changed.h>
 #include <zmk/events/layer_state_changed.h>
 #include <math.h>
-
 #include <stdlib.h>
 
 int random0to100()
@@ -42,10 +41,6 @@ static int8_t current_brightness = CONFIG_DONGLE_SCREEN_MAX_BRIGHTNESS;
 static uint8_t ambient_min_brightness = CONFIG_DONGLE_SCREEN_AMBIENT_LIGHT_MIN_BRIGHTNESS;
 #endif
 
-#ifndef M_PI // No M_Pi in math.h
-#define M_PI 3.14159265358979323846
-#endif
-
 static int8_t brightness_modifier = 0;
 
 static uint8_t clamp_brightness(int8_t value)
@@ -68,59 +63,99 @@ static void apply_brightness(uint8_t value)
     LOG_INF("Screen brightness set to %d", value);
 }
 
+
+
+
+// Threaded fade logic
+// Contains starting and target brightness levels to be animated
+struct fade_request_t {
+    uint8_t from;           // Starting brightness level
+    uint8_t to;             // Target brightness level
+};
+
+#define FADE_QUEUE_SIZE 4
+
+// Message queue used to send fade requests to the fade handler thread.
+// It holds up to 4 fade_request_t elements and ensures brightness updates are handled sequentially.
+K_MSGQ_DEFINE(fade_msgq, sizeof(struct fade_request_t), FADE_QUEUE_SIZE, 4);
+
+// Cubic ease-in-out function to smooth the interpolation curve.
+// Provides a natural "S-curve" animation effect: starts slow, accelerates, then slows again.
+// Helps avoid abrupt changes in perceived brightness.
+// delete old cpu heavy cons calculation
+static float ease_in_out(float t) {
+    if (t < 0.5f) return 4.0f * t * t * t;
+    float f = -2.0f * t + 2.0f;
+    return 1.0f - (f * f * f) / 2.0f;
+}
+
+// Dedicated thread responsible for handling all fade animations.
+// Receives fade requests from the queue and applies brightness changes over time using easing.
+void fade_thread(void) {
+    struct fade_request_t req;
+
+    while (1) {
+        // Wait indefinitely for the next fade request to arrive in the queue
+        if (k_msgq_get(&fade_msgq, &req, K_FOREVER) == 0) {
+
+            // Skip animation entirely if brightness difference is too small
+            if (req.from == req.to || abs(req.to - req.from) <= 1) {
+                apply_brightness(req.to);
+                continue;
+            }
+
+            // Calculate brightness difference and use it to determine number of steps
+            int diff = abs(req.to - req.from);
+            int steps = CLAMP(diff * 2, 6, 32); // More steps for smoother fades over large differences
+
+            // Set total animation time: scale with difference but clamp between 500ms and 1000ms
+            int total_duration_ms = CLAMP(diff * 20, 500, 1000); // 20ms per level as baseline
+            int delay_us = (total_duration_ms * 1000) / steps;   // Delay between steps in microseconds
+
+            uint8_t last_applied = 255; // Used to prevent redundant LED updates to save performance
+
+            // Interpolate brightness across 'steps' frames using easing
+            for (int i = 0; i <= steps; i++) {
+                float t = (float)i / steps;                // Normalized time in [0, 1]
+                float eased = ease_in_out(t);              // Eased time for smoother progression
+                float interpolated = req.from + (req.to - req.from) * eased; // Interpolated value
+                uint8_t brightness = (uint8_t)(interpolated + 0.5f);         // Rounded to nearest integer
+
+                // Only send update if brightness actually changed
+                if (brightness != last_applied) {
+                    apply_brightness(brightness);
+                    last_applied = brightness;
+                }
+
+                k_usleep(delay_us); // Sleep before next step to pace the fade
+            }
+
+            // safeguard to ensure the target value is set at the end
+            if (last_applied != req.to) {
+                apply_brightness(req.to);
+            }
+        }
+    }
+}
+
+// Launch the fade thread with 768 bytes of stack, medium priority (6)
+// 512 was too small for logging, math (float, int), small loop, few stack-local variables
+// 768 is just a guess, optimization is possible, probably
+K_THREAD_DEFINE(fade_tid, 768, fade_thread, NULL, NULL, NULL, 6, 0, 0);
+
+// Function to submit a brightness fade request
+// Ensures that only the most recent fade request is applied by purging the queue first for changes in between animations
 static void fade_to_brightness(uint8_t from, uint8_t to)
 {
-    if (from == to)
-    {
-        apply_brightness(to);
-        return;
-    }
-
-    const int step_delay = BRIGHTNESS_DELAY_MS;
-    const int abs_diff = abs(to - from); // Total number of brightness steps in the fade
-
-    /*
-    Adjust the duration of the fade depending on how small the change is:
-        - Small changes -> longer fade
-        - For larger changes -> cap to avoid long transitions
-    */
-    int dynamic_duration = abs_diff < 4 ? 1000 : BRIGHTNESS_FADE_DURATION_MS;
-
-    // Clamp duration to always be between 500ms and 1000ms
-    if (dynamic_duration < 500)
-        dynamic_duration = 500; // Minimum fade duration
-    if (dynamic_duration > 1000)
-        dynamic_duration = 1000; // Maximum fade duration
-
-    const int steps = dynamic_duration / step_delay; // Total number of animation steps
-
-    float diff = to - from;
-    float tmp_brightness = 0.0f;
-    uint8_t last_applied = 255; // Keeps track of last value sent to avoid redundant updates. 225, first "rounded != last_applied" will always true
-
-    for (int i = 0; i <= steps; i++)
-    {
-        float t = (float)i / steps; // Normalized time value: 0.0 at start, 1.0 at end
-
-        /*
-         Cosine easing (ease-in-out): (1 - cos(t * π)) / 2
-            - Starts slow, accelerates in the middle, slows down again
-            - Produces a smooth S-curve transitio flat > steep > flat
-        */
-        float eased = (1.0f - cosf(t * M_PI)) / 2.0f;
-        tmp_brightness = from + diff * eased;               // Interpolate the brightness using eased values
-        uint8_t rounded = (uint8_t)(tmp_brightness + 0.5f); // Convert float brightness to nearest integer
-
-        // Only apply brightness if it actually changed - avoids redundant LED updates
-        if (rounded != last_applied)
-        {
-            apply_brightness(rounded);
-            last_applied = rounded;
-        }
-        k_msleep(step_delay);
-    }
-    apply_brightness(to); // Ensure the final brightness is applied to the end value
+    struct fade_request_t req = { .from = from, .to = to };
+    k_msgq_purge(&fade_msgq);          // Clear any pending fades to avoid outdated transitions
+    k_msgq_put(&fade_msgq, &req, K_NO_WAIT); // Submit the new fade request without blocking
 }
+
+
+
+
+
 
 void set_screen_brightness(uint8_t value, bool ambient)
 {


### PR DESCRIPTION
### What I changed:

- Moved `fade_to_brightness()` logic into its own thread to completely avoid blocking the main execution thread for idle.

- Created a` k_msgq (message queue)` to buffer brightness transition requests and decouple fade execution from the caller.

- Implemented `fade_thread()`, which processes brightness transitions using cubic ease-in-out interpolation to improve visual smoothness — all without expensive cosine calculations at runtime.

- The queue is cleared before adding a new request, so only the most recent brightness target is applied. In case the lighting conditions change during the animation


### The Benefits:

- No more blocking of performance-sensitive threads (e.g., ambient light handling, idle timeouts).
- Multiple sources (e.g., light sensor, keyboard events) can safely trigger fades without interference.
- Clean, smooth fade transitions using easing curves.
- Avoids redundant LED updates for better performance.
