### PR TITLE
Wake the screen up when a peripheral is reconnecting

### DIFF
--- a/boards/shields/dongle_screen/src/brightness.c
+++ b/boards/shields/dongle_screen/src/brightness.c
@@ -136,7 +136,26 @@ void screen_idle_thread(void)
 
 K_THREAD_DEFINE(screen_idle_tid, 512, screen_idle_thread, NULL, NULL, NULL, 7, 0, 0);
 
-#endif // CONFIG_DONGLE_SCREEN_IDLE_TIMEOUT_S > 0
+void brightness_wake_screen_on_reconnect(void)
+{
+    if (!screen_on)
+    {
+        LOG_INF("Peripheral reconnected, waking screen");
+
+        screen_set_on(true);
+
+        // Reset idle timer
+        last_activity = k_uptime_get();
+
+        k_wakeup(screen_idle_tid);
+    }
+    else
+    {
+        LOG_DBG("Peripheral reconnected but screen already on");
+    }
+}
+
+#endif
 
 // --- Brightness control via keyboard ---
 

--- a/boards/shields/dongle_screen/src/brightness.h
+++ b/boards/shields/dongle_screen/src/brightness.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+/**
+ * @brief Wake the screen when a peripheral reconnects
+ * Called by battery widget when it detects a peripheral reconnection
+ */
+void brightness_wake_screen_on_reconnect(void);


### PR DESCRIPTION
This PR changes the behavior to try to wake up the screen if a peripheral is reconnecting again. This is done via the battery event.